### PR TITLE
fix #24: <rect> shapes not cloning in Chrome

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -122,8 +122,12 @@
                 copyStyle(global.window.getComputedStyle(original), clone.style);
 
                 function copyStyle(source, target) {
-                    if (source.cssText) target.cssText = source.cssText;
-                    else copyProperties(source, target);
+                    // Chrome not cloning <rect> shapes due to width and height properties,
+                    // strip these properties from cssText string if element is a <rect>.
+                    if (source.cssText)
+                        target.cssText = (clone.tagName === 'rect') ? source.cssText.replace(/(^|\s)(width|height).*?\;/gi, '') : source.cssText;
+                    else
+                        copyProperties(source, target);
 
                     function copyProperties(source, target) {
                         util.asArray(source).forEach(function (name) {


### PR DESCRIPTION
After digging through `cssText` properties applied when cloning `<rect>`, it appears that `height` and `width` are the underlying root cause to the clone not rendering properly. 

The simplest fix I can see at first glance is to simply check if this is a `<rect>` shape and strip these properties from the `cssText` string all together. 

I only apply this logic to `cssText` as this issue is specific to Chrome and Chrome seems to predominantly use the `cssText` string.
